### PR TITLE
'random' module depreciation warning

### DIFF
--- a/lib/gen_retry/worker.ex
+++ b/lib/gen_retry/worker.ex
@@ -43,7 +43,7 @@ defmodule GenRetry.Worker do
   @spec delay_time(GenRetry.State.t) :: integer
   defp delay_time(state) do
     base_delay = state.opts.delay * :math.pow(state.opts.exp_base, state.tries)
-    jitter = :random.uniform * base_delay * state.opts.jitter
+    jitter = :rand.uniform * base_delay * state.opts.jitter
     round(base_delay + jitter)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule GenRetry.Mixfile do
     [app: :gen_retry,
      description: description,
      package: package,
-     version: "1.0.0",
+     version: "1.0.1",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Just a simple change to `:rand.uniform` to get rid of the depreciation warning on `:random.uniform`

If you do not want the version bumped, feel free to remove that or I can resubmit without that change.

```
warning: random:uniform/0: the 'random' module is deprecated; use the 'rand' module instead
  lib/gen_retry/worker.ex:46
```
