### PR TITLE
Add `on_success` and `on_failure` function callbacks

### DIFF
--- a/lib/gen_retry/worker.ex
+++ b/lib/gen_retry/worker.ex
@@ -30,6 +30,10 @@ defmodule GenRetry.Worker do
         send(pid, {:success, return_value, state})
       end
 
+      if on_success = state.opts.on_success do
+        on_success.({return_value, state})
+      end
+
       {:stop, :normal, state}
     rescue
       e ->
@@ -42,6 +46,10 @@ defmodule GenRetry.Worker do
         else
           if pid = state.opts.respond_to do
             send(pid, {:failure, e, __STACKTRACE__, state})
+          end
+
+          if on_failure = state.opts.on_failure do
+            on_failure.({e, __STACKTRACE__, state})
           end
 
           {:stop, :normal, state}

--- a/lib/gen_retry/worker.ex
+++ b/lib/gen_retry/worker.ex
@@ -33,8 +33,6 @@ defmodule GenRetry.Worker do
       {:stop, :normal, state}
     rescue
       e ->
-        trace = System.stacktrace()
-
         state.logger.log(inspect(e))
 
         if should_try_again(state) do
@@ -43,7 +41,7 @@ defmodule GenRetry.Worker do
           {:noreply, %{state | retry_at: retry_at}}
         else
           if pid = state.opts.respond_to do
-            send(pid, {:failure, e, trace, state})
+            send(pid, {:failure, e, __STACKTRACE__, state})
           end
 
           {:stop, :normal, state}

--- a/test/gen_retry_test.exs
+++ b/test/gen_retry_test.exs
@@ -8,4 +8,33 @@ defmodule GenRetryTest do
       assert(22 == Task.await(t))
     end
   end
+
+  context "GenRetry.retry_link" do
+    it "uses on_success" do
+      pid = self()
+
+      GenRetry.retry_link(
+        fn -> 23 end,
+        on_success: fn succ -> send(pid, succ) end,
+        on_failure: fn fail -> send(pid, {:failure, fail}) end
+      )
+
+      assert_receive {23, %{}}
+      refute_receive {:failure, _}
+    end
+
+    it "uses on_failure" do
+      pid = self()
+
+      GenRetry.retry_link(
+        fn -> raise "oops" end,
+        retries: 0,
+        on_success: fn succ -> send(pid, {:success, succ}) end,
+        on_failure: fn fail -> send(pid, {:failure, fail}) end
+      )
+
+      assert_receive({:failure, {_exception, _stacktrace, %{}}})
+      refute_receive({:success, _})
+    end
+  end
 end


### PR DESCRIPTION
Hi,

First off, thanks for writing this library.

Sometimes when I'm using this library I wish for more flexibility. Adding on_success and on_failure (although I'm only planning on using on_failure, implementing on_success also seemed logical) allows use of closures that give this flexibility.

Example:

```
pid = self()
some_id = 42
on_failure = fn _failure ->
  send(pid, {:failure, some_id})
end

GenRetry.retry_link(fn ->
  case try_something() do
    {:ok, result} -> send(pid, {:success, result})
    _ -> raise "oops, try again"
  end
end)
```

It's otherwise quite difficult to figure out from the normal `respond_to` feature *which* task has passed or failed. Or I'd have to wrap the GenRetry in its own GenServer, but I'd rather not.

So, I hope you accept this PR :pray:

Cheers
Derek