### PR TITLE
Better error logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 erl_crash.dump
 *.ez
 /doc
-
+/.elixir_ls/

--- a/lib/gen_retry/worker.ex
+++ b/lib/gen_retry/worker.ex
@@ -37,7 +37,7 @@ defmodule GenRetry.Worker do
       {:stop, :normal, state}
     rescue
       e ->
-        state.logger.log(inspect(e))
+        state.logger.log(Exception.format(:error, e, __STACKTRACE__))
 
         if should_try_again(state) do
           retry_at = :erlang.system_time(:milli_seconds) + delay_time(state)


### PR DESCRIPTION
Use Elixir [`Exception.format/3`](https://hexdocs.pm/elixir/Exception.html#format/3) to nicely format the errors with a stack trace.

```bash
** (RuntimeError) An Error!
    test/worker_test.exs:17: anonymous fn/0 in GenRetry.WorkerTest.\"test logger logs errors as they happen before retrying\"/1
    (gen_retry) lib/gen_retry/worker.ex:27: GenRetry.Worker.handle_cast/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

Also run `mix format`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/appcues/gen_retry/9)
<!-- Reviewable:end -->
