### PR TITLE
Fix `WorkerTest` and compiler warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -28,4 +26,4 @@ config :gen_retry, GenRetry.Logger, logger: GenRetry.Utils
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :gen_retry, GenRetry.Logger, logger: GenRetry.TestLogger

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :gen_retry, GenRetry.Logger, logger: GenRetry.TestLogger

--- a/lib/gen_retry.ex
+++ b/lib/gen_retry.ex
@@ -94,7 +94,13 @@ defmodule GenRetry do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(GenRetry.Launcher, [[], [name: :gen_retry_launcher]])
+      %{
+        id: GenRetry.Launcher,
+        start:
+          {GenRetry.Launcher, :start_link, [[], [name: :gen_retry_launcher]]},
+        type: :worker,
+        restart: :permanent
+      }
     ]
 
     opts = [strategy: :one_for_one, name: GenRetry.Supervisor]

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule GenRetry.Mixfile do
       description: description(),
       package: package(),
       version: "1.4.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -7,16 +7,12 @@ defmodule GenRetry.WorkerTest do
     it "logs errors as they happen before retrying" do
       with_mock GenRetry.TestLogger, log: fn _ -> nil end do
         try do
-          task =
-            GenRetry.Task.async(fn ->
-              raise("An Error!")
-            end)
+          task = GenRetry.Task.async(fn -> raise "An Error!" end)
+          :erlang.unlink(task.pid)
 
-          :timer.sleep(100)
-
-          GenRetry.Task.await(task)
-        rescue
-          _ -> "squelch error"
+          Task.await(task)
+        catch
+          :exit, _ -> "squelch error"
         end
 
         assert_called(


### PR DESCRIPTION
I would love if this ugly warning disappeared

```
$ mix deps.compile --force gen_retry
==> gen_retry
Compiling 7 files (.ex)
warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/gen_retry.ex:97: GenRetry.start/2
```

I've also migrated from the deprecated `use Mix.Config` (which requires [elixir 1.9](https://hexdocs.pm/elixir/1.13.4/Config.html#module-migrating-from-use-mix-config), not sure if this is ok) and since I was getting this warning when I tried `mix test`

```
warning: GenRetry.Task.await/1 is undefined or private
  test/worker_test.exs:17: GenRetry.WorkerTest."test logger logs errors as they happen before retrying"/1
```

I've also tried to fix this issue (not sure if this is ok too :smile: )

cheers :beers: 